### PR TITLE
Refactor/#30 주문 엔티티 필드 이름 수정

### DIFF
--- a/src/main/java/com/toyland/order/model/Order.java
+++ b/src/main/java/com/toyland/order/model/Order.java
@@ -27,5 +27,5 @@ public class Order {
 
     @Enumerated(value = EnumType.STRING)
     @Column(name = "payment_Type")
-    private PaymentType payment_type; // 결제유형(카드/현금)
+    private PaymentType paymentType; // 결제유형(카드/현금)
 }

--- a/src/main/java/com/toyland/order/model/Order.java
+++ b/src/main/java/com/toyland/order/model/Order.java
@@ -14,15 +14,18 @@ public class Order {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "id", updatable = false, nullable = false)
+    @Column(name = "order_id", updatable = false, nullable = false)
     private UUID id;
 
     @Enumerated(value = EnumType.STRING)
-    private OrderStatus order_status; // 주문상태(주문완료/주문취소/조리중/배달중/배달완료)
+    @Column(name = "order_status")
+    private OrderStatus orderStatus; // 주문상태(주문완료/주문취소/조리중/배달중/배달완료)
 
     @Enumerated(value = EnumType.STRING)
-    private OrderType order_type; // 주문유형(포장/배달)
+    @Column(name = "order_type")
+    private OrderType orderType; // 주문유형(포장/배달)
 
     @Enumerated(value = EnumType.STRING)
+    @Column(name = "paymentType")
     private PaymentType payment_type; // 결제유형(카드/현금)
 }

--- a/src/main/java/com/toyland/order/model/Order.java
+++ b/src/main/java/com/toyland/order/model/Order.java
@@ -26,6 +26,6 @@ public class Order {
     private OrderType orderType; // 주문유형(포장/배달)
 
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "paymentType")
+    @Column(name = "payment_Type")
     private PaymentType payment_type; // 결제유형(카드/현금)
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #30 

## 변경 타입
- [x] 리팩토링


## 변경 내용
- Order 엔티티의 order_type과 같은 기존 데이터베이스 컬럼 네이밍을 자바 네이밍 컨벤션에 맞게 orderType으로 변경하고, column(name = "order_type")을 명시적으로 적용

- **to-be**(변경 후 설명을 여기에 작성)
 -order_type → orderType 변경
 -order_status → orderStatus 변경
 -payment_type → paymentType 변경

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.