### PR TITLE
Feature/#34 [OrderProduct] 주문상품 생성, 주문과 외래키(연관관계) 설정

### DIFF
--- a/src/main/java/com/toyland/order/model/Order.java
+++ b/src/main/java/com/toyland/order/model/Order.java
@@ -1,9 +1,12 @@
 package com.toyland.order.model;
 
+import com.toyland.orderproduct.model.OrderProduct;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -28,4 +31,11 @@ public class Order {
     @Enumerated(value = EnumType.STRING)
     @Column(name = "payment_Type")
     private PaymentType paymentType; // 결제유형(카드/현금)
+
+    @OneToMany
+    @JoinColumn(name = "order_id") // p_order_product 테이블에 order_id 컬럼으로 외래키 설정
+    private List<OrderProduct> orderProductList = new ArrayList<>();
+
+    // 회원 ID (FK, 실제 DB에는 존재하지만 엔티티에는 존재하지 않음)
+    // private UUID user_id;
 }

--- a/src/main/java/com/toyland/order/model/Order.java
+++ b/src/main/java/com/toyland/order/model/Order.java
@@ -1,5 +1,6 @@
 package com.toyland.order.model;
 
+import com.toyland.user.model.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +30,7 @@ public class Order {
     @Column(name = "payment_Type")
     private PaymentType paymentType; // 결제유형(카드/현금)
 
-    // 회원 ID (FK, 실제 DB에는 존재하지만 엔티티에는 존재하지 않음)
-    // private UUID user_id;
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false) // p_user 테이블의 user_id를 FK로 설정
+    private User user;
 }

--- a/src/main/java/com/toyland/order/model/Order.java
+++ b/src/main/java/com/toyland/order/model/Order.java
@@ -1,12 +1,9 @@
 package com.toyland.order.model;
 
-import com.toyland.orderproduct.model.OrderProduct;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -31,10 +28,6 @@ public class Order {
     @Enumerated(value = EnumType.STRING)
     @Column(name = "payment_Type")
     private PaymentType paymentType; // 결제유형(카드/현금)
-
-    @OneToMany
-    @JoinColumn(name = "order_id") // p_order_product 테이블에 order_id 컬럼으로 외래키 설정
-    private List<OrderProduct> orderProductList = new ArrayList<>();
 
     // 회원 ID (FK, 실제 DB에는 존재하지만 엔티티에는 존재하지 않음)
     // private UUID user_id;

--- a/src/main/java/com/toyland/orderproduct/model/OrderProduct.java
+++ b/src/main/java/com/toyland/orderproduct/model/OrderProduct.java
@@ -1,0 +1,29 @@
+package com.toyland.orderproduct.model;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "p_order_product")
+public class OrderProduct {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "order_product_id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "order_product_price", updatable = false, nullable = false)
+    private String orderProductPrice; // 주문 가격(주문 당시 가격)
+
+    @Column(name = "content", nullable = false)
+    private String quantity;
+
+    // 주문 ID (FK, 실제 DB에는 존재하지만 엔티티에는 존재하지 않음)
+    // private UUID order_id;
+}

--- a/src/main/java/com/toyland/orderproduct/model/OrderProduct.java
+++ b/src/main/java/com/toyland/orderproduct/model/OrderProduct.java
@@ -1,6 +1,7 @@
 package com.toyland.orderproduct.model;
 
 
+import com.toyland.order.model.Order;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,7 @@ public class OrderProduct {
     @Column(name = "content", nullable = false)
     private String quantity;
 
-    // 주문 ID (FK, 실제 DB에는 존재하지만 엔티티에는 존재하지 않음)
-    // private UUID order_id;
+    @ManyToOne
+    @JoinColumn(name = "order_id") // p_order 테이블의 order_id로 외래키(FK) 설정
+    private Order order;
 }

--- a/src/main/java/com/toyland/orderproduct/model/OrderProduct.java
+++ b/src/main/java/com/toyland/orderproduct/model/OrderProduct.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.util.UUID;
 
 @Getter
@@ -20,12 +21,12 @@ public class OrderProduct {
     private UUID id;
 
     @Column(name = "order_product_price", updatable = false, nullable = false)
-    private String orderProductPrice; // 주문 가격(주문 당시 가격)
+    private BigDecimal orderProductPrice; // 주문 가격(주문 당시 가격)
 
-    @Column(name = "content", nullable = false)
-    private String quantity;
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
 
     @ManyToOne
-    @JoinColumn(name = "order_id") // p_order 테이블의 order_id로 외래키(FK) 설정
+    @JoinColumn(name = "order_id", nullable = false) // p_order 테이블의 order_id로 외래키(FK) 설정
     private Order order;
 }

--- a/src/main/java/com/toyland/user/model/User.java
+++ b/src/main/java/com/toyland/user/model/User.java
@@ -1,13 +1,10 @@
 package com.toyland.user.model;
 
-import com.toyland.order.model.Order;
+
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
@@ -28,10 +25,6 @@ public class User{
     @Column(nullable = false)
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
-
-    @OneToMany
-    @JoinColumn(name = "user_id") // p_order 테이블에 user_id 컬럼
-    private List<Order> orderList = new ArrayList<>();
 
 
     public User(String username, String password, UserRoleEnum role) {


### PR DESCRIPTION
## #️⃣연관된 이슈
- 이슈 번호: #34 

## 변경 타입
- [x] 신규 기능 추가/수정

## 변경 내용
- **to-be**(변경 후 설명을 여기에 작성)
 -주문상품 entity 추가
 -주문상품 테이블 생성 및 주문 테이블과 외래키 설정

## 체크리스트
- [x] 코드가 제대로 동작하는지 확인했습니다.

## 코멘트
- @OneToMany로 설계했을 때 INSERT 발생 시 추가적인 UPDATE가 필요다는 점과 Entity에서 외래키를 매핑하는 필드가 보이지 않아 파악하기 어려운 단점이 있어 @ManyToOne 으로 설계
- 향후 Order에서 OrderProduct를 조회하는 경우가 필요할 때 양방향 고려